### PR TITLE
Fix missing coastal routes module

### DIFF
--- a/FinalFRP/backend/routes/routingRoutes.js
+++ b/FinalFRP/backend/routes/routingRoutes.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const router = express.Router();
 const routingService = require('../services/routingService');
-const coastalRoutes = require('../data/coastalRoutes.json');
 
 // Generic coastal paths for fallback path generation
 const coastalPaths = {


### PR DESCRIPTION
## Summary
- remove unused coastalRoutes require in `routingRoutes`

## Testing
- `npm test -- --passWithNoTests --silent`

------
https://chatgpt.com/codex/tasks/task_e_6889b9b98f6c8323923db6b11a709c15